### PR TITLE
Laravel Nova 4.0 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "license": "MIT",
     "require": {
         "php": "^7.4|^8.0|^8.1",
-        "spatie/laravel-permission": "^3.0|^4.0|^5.0"
+        "spatie/laravel-permission": "^3.0|^4.0|^5.0",
+        "laravel/nova": "^4.0",
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.4|^8.0|^8.1",
         "spatie/laravel-permission": "^3.0|^4.0|^5.0",
-        "laravel/nova": "^4.0",
+        "laravel/nova": "^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/AttachToRole.php
+++ b/src/AttachToRole.php
@@ -3,12 +3,13 @@
 namespace Vyuldashev\NovaPermission;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Collection;
-use Laravel\Nova\Actions\Action;
-use Laravel\Nova\Fields\ActionFields;
 use Laravel\Nova\Fields\Select;
+use Laravel\Nova\Actions\Action;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Fields\ActionFields;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Laravel\Nova\Http\Requests\NovaRequest;
 
 class AttachToRole extends Action
 {
@@ -34,7 +35,7 @@ class AttachToRole extends Action
      *
      * @return array
      */
-    public function fields()
+    public function fields(NovaRequest $request)
     {
         return [
             Select::make('Role')->options(Role::getModel()->get()->pluck('name', 'id')->toArray())->displayUsingLabels(),

--- a/src/AttachToRole.php
+++ b/src/AttachToRole.php
@@ -33,6 +33,7 @@ class AttachToRole extends Action
     /**
      * Get the fields available on the action.
      *
+     * @param NovaRequest $request
      * @return array
      */
     public function fields(NovaRequest $request)

--- a/src/NovaPermissionTool.php
+++ b/src/NovaPermissionTool.php
@@ -5,6 +5,8 @@ namespace Vyuldashev\NovaPermission;
 use Gate;
 use Laravel\Nova\Nova;
 use Laravel\Nova\Tool;
+use Illuminate\Http\Request;
+use Laravel\Nova\Menu\MenuSection;
 
 class NovaPermissionTool extends Tool
 {
@@ -14,11 +16,7 @@ class NovaPermissionTool extends Tool
     public string $rolePolicy = RolePolicy::class;
     public string $permissionPolicy = PermissionPolicy::class;
 
-    /**
-     * Perform any tasks that need to happen when the tool is booted.
-     *
-     * @return void
-     */
+
     public function boot()
     {
         Nova::resources([
@@ -28,6 +26,19 @@ class NovaPermissionTool extends Tool
 
         Gate::policy(config('permission.models.permission'), $this->permissionPolicy);
         Gate::policy(config('permission.models.role'), $this->rolePolicy);
+    }
+
+    /**
+     * Build the menu that renders the navigation links for the tool.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @return mixed
+     */
+    public function menu(Request $request)
+    {
+        return MenuSection::make('Test')
+            ->path('/test')
+            ->icon('server');
     }
 
     public function roleResource(string $roleResource): NovaPermissionTool

--- a/src/NovaPermissionTool.php
+++ b/src/NovaPermissionTool.php
@@ -16,7 +16,11 @@ class NovaPermissionTool extends Tool
     public string $rolePolicy = RolePolicy::class;
     public string $permissionPolicy = PermissionPolicy::class;
 
-
+    /**
+     * Perform any tasks that need to happen when the tool is booted.
+     *
+     * @return void
+     */
     public function boot()
     {
         Nova::resources([

--- a/src/NovaPermissionTool.php
+++ b/src/NovaPermissionTool.php
@@ -40,9 +40,7 @@ class NovaPermissionTool extends Tool
      */
     public function menu(Request $request)
     {
-        return MenuSection::make('Test')
-            ->path('/test')
-            ->icon('server');
+        //
     }
 
     public function roleResource(string $roleResource): NovaPermissionTool

--- a/src/Permission.php
+++ b/src/Permission.php
@@ -2,17 +2,18 @@
 
 namespace Vyuldashev\NovaPermission;
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
-use Illuminate\Validation\Rule;
-use Laravel\Nova\Fields\DateTime;
-use Laravel\Nova\Fields\ID;
-use Laravel\Nova\Fields\MorphToMany;
-use Laravel\Nova\Fields\Select;
-use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Nova;
 use Laravel\Nova\Resource;
+use Laravel\Nova\Fields\ID;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Text;
+use Illuminate\Validation\Rule;
+use Laravel\Nova\Fields\Select;
+use Laravel\Nova\Fields\DateTime;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Nova\Fields\MorphToMany;
 use Spatie\Permission\PermissionRegistrar;
+use Laravel\Nova\Http\Requests\NovaRequest;
 
 class Permission extends Resource
 {
@@ -78,10 +79,10 @@ class Permission extends Resource
     /**
      * Get the fields displayed by the resource.
      *
-     * @param Request $request
+     * @param NovaRequest $request
      * @return array
      */
-    public function fields(Request $request): array
+    public function fields(NovaRequest $request)
     {
         $guardOptions = collect(config('auth.guards'))->mapWithKeys(function ($value, $key) {
             return [$key => $key];
@@ -121,10 +122,10 @@ class Permission extends Resource
     /**
      * Get the cards available for the request.
      *
-     * @param Request $request
+     * @param NovaRequest $request
      * @return array
      */
-    public function cards(Request $request): array
+    public function cards(NovaRequest $request): array
     {
         return [];
     }
@@ -132,10 +133,10 @@ class Permission extends Resource
     /**
      * Get the filters available for the resource.
      *
-     * @param Request $request
+     * @param NovaRequest $request
      * @return array
      */
-    public function filters(Request $request): array
+    public function filters(NovaRequest $request): array
     {
         return [];
     }
@@ -143,10 +144,10 @@ class Permission extends Resource
     /**
      * Get the lenses available for the resource.
      *
-     * @param Request $request
+     * @param NovaRequest $request
      * @return array
      */
-    public function lenses(Request $request): array
+    public function lenses(NovaRequest $request): array
     {
         return [];
     }
@@ -154,10 +155,10 @@ class Permission extends Resource
     /**
      * Get the actions available for the resource.
      *
-     * @param Request $request
+     * @param NovaRequest $request
      * @return array
      */
-    public function actions(Request $request): array
+    public function actions(NovaRequest $request): array
     {
         return [
             new AttachToRole,

--- a/src/Role.php
+++ b/src/Role.php
@@ -105,7 +105,7 @@ class Role extends Resource
             DateTime::make(__('nova-permission-tool::roles.created_at'), 'created_at')->exceptOnForms(),
             DateTime::make(__('nova-permission-tool::roles.updated_at'), 'updated_at')->exceptOnForms(),
 
-            //PermissionBooleanGroup::make(__('nova-permission-tool::roles.permissions'), 'permissions'),
+            PermissionBooleanGroup::make(__('nova-permission-tool::roles.permissions'), 'permissions'),
 
             MorphToMany::make($userResource::label(), 'users', $userResource)
                 ->searchable()

--- a/src/Role.php
+++ b/src/Role.php
@@ -2,17 +2,18 @@
 
 namespace Vyuldashev\NovaPermission;
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
-use Illuminate\Validation\Rule;
-use Laravel\Nova\Fields\DateTime;
-use Laravel\Nova\Fields\ID;
-use Laravel\Nova\Fields\MorphToMany;
-use Laravel\Nova\Fields\Select;
-use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Nova;
 use Laravel\Nova\Resource;
+use Laravel\Nova\Fields\ID;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Text;
+use Illuminate\Validation\Rule;
+use Laravel\Nova\Fields\Select;
+use Laravel\Nova\Fields\DateTime;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Nova\Fields\MorphToMany;
 use Spatie\Permission\PermissionRegistrar;
+use Laravel\Nova\Http\Requests\NovaRequest;
 
 class Role extends Resource
 {
@@ -78,10 +79,10 @@ class Role extends Resource
     /**
      * Get the fields displayed by the resource.
      *
-     * @param Request $request
+     * @param NovaRequest $request
      * @return array
      */
-    public function fields(Request $request)
+    public function fields(NovaRequest $request)
     {
         $guardOptions = collect(config('auth.guards'))->mapWithKeys(function ($value, $key) {
             return [$key => $key];
@@ -104,7 +105,7 @@ class Role extends Resource
             DateTime::make(__('nova-permission-tool::roles.created_at'), 'created_at')->exceptOnForms(),
             DateTime::make(__('nova-permission-tool::roles.updated_at'), 'updated_at')->exceptOnForms(),
 
-            PermissionBooleanGroup::make(__('nova-permission-tool::roles.permissions'), 'permissions'),
+            //PermissionBooleanGroup::make(__('nova-permission-tool::roles.permissions'), 'permissions'),
 
             MorphToMany::make($userResource::label(), 'users', $userResource)
                 ->searchable()
@@ -115,10 +116,10 @@ class Role extends Resource
     /**
      * Get the cards available for the request.
      *
-     * @param Request $request
+     * @param NovaRequest $request
      * @return array
      */
-    public function cards(Request $request)
+    public function cards(NovaRequest $request)
     {
         return [];
     }
@@ -126,10 +127,10 @@ class Role extends Resource
     /**
      * Get the filters available for the resource.
      *
-     * @param Request $request
+     * @param NovaRequest $request
      * @return array
      */
-    public function filters(Request $request)
+    public function filters(NovaRequest $request)
     {
         return [];
     }
@@ -137,10 +138,10 @@ class Role extends Resource
     /**
      * Get the lenses available for the resource.
      *
-     * @param Request $request
+     * @param NovaRequest $request
      * @return array
      */
-    public function lenses(Request $request)
+    public function lenses(NovaRequest $request)
     {
         return [];
     }
@@ -148,10 +149,10 @@ class Role extends Resource
     /**
      * Get the actions available for the resource.
      *
-     * @param Request $request
+     * @param NovaRequest $request
      * @return array
      */
-    public function actions(Request $request)
+    public function actions(NovaRequest $request)
     {
         return [];
     }


### PR DESCRIPTION
This adds Laravel 4.0 support. 

Will likely need to be a new major version as it is not backwards compatible with 3.x