### PR TITLE
Update NovaPermissionTool

### DIFF
--- a/src/NovaPermissionTool.php
+++ b/src/NovaPermissionTool.php
@@ -70,4 +70,10 @@ class NovaPermissionTool extends Tool
 
         return $this;
     }
+    
+    // This is an abstract method in nova Tool class, so we MUST implement it.
+    public function menu(Request $request)
+    {
+        return $this;
+    }
 }


### PR DESCRIPTION
Without this definition, I am running in to this error:

```
[29-Apr-2022 14:45:13 UTC] PHP Fatal error:  Class Vyuldashev\NovaPermission\NovaPermissionTool contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Laravel\Nova\Tool::menu) in /.../vendor/vyuldashev/nova-permission/src/NovaPermissionTool.php on line 0
```