### PR TITLE
[Fix] Role replicate function in Nova 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kiritokatklian/nova-permission",
+    "name": "charlielangridge/nova-permission",
     "description": "A Laravel Nova tool for Spatie's Permission library.",
     "keywords": [
         "laravel",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "charlielangridge/nova-permission",
+    "name": "kiritokatklian/nova-permission",
     "description": "A Laravel Nova tool for Spatie's Permission library.",
     "keywords": [
         "laravel",

--- a/src/Role.php
+++ b/src/Role.php
@@ -165,4 +165,19 @@ class Role extends Resource
     {
         return [];
     }
+    
+    /**
+     * 
+     * Allow the permissions to replicate with the Role
+     * 
+     * @return Role|HigherOrderTapProxy|mixed
+     */
+    public function replicate()
+    {
+        return tap(parent::replicate(), function ($resource) {
+            $model = $resource->model();
+            $model->name = 'Duplicate of '.$model->name;
+            $model->permissions = parent::model()->permissions;
+        });
+    }
 }


### PR DESCRIPTION
This copies there permission to be replicated when a role is replicated