### PR TITLE
Fix AttachToRole action for v6

### DIFF
--- a/src/Role.php
+++ b/src/Role.php
@@ -51,7 +51,9 @@ class Role extends Resource
 
     public static function getModel()
     {
-        return app(PermissionRegistrar::class)->getRoleClass();
+        $object = app(PermissionRegistrar::class)->getRoleClass();
+
+        return \is_string($object) ? app($object) : $object;
     }
 
     /**


### PR DESCRIPTION
The Registrar no longer always returns an object, but a string representing the object's name, which must be instantiated.

If not instantiated, you have this exception, due to the string `'Spatie\Permission\Models\Role'`:

<img width="840" alt="Screenshot 2023-11-15 - 17-15-31@2x" src="https://github.com/kiritokatklian/nova-permission/assets/408237/9879523b-7261-4efc-b2cb-48d99c7d04e9">
