### PR TITLE
fix: Laravel Permissions v5 Support

### DIFF
--- a/src/Permission.php
+++ b/src/Permission.php
@@ -68,7 +68,9 @@ class Permission extends Resource
      */
     public static function getModel(): string
     {
-        return app(PermissionRegistrar::class)->getPermissionClass();
+        $permissionClass = app(PermissionRegistrar::class)->getPermissionClass();
+
+        return is_string($permissionClass) ? $permissionClass : get_class($permissionClass);
     }
 
     /**

--- a/src/Role.php
+++ b/src/Role.php
@@ -68,7 +68,9 @@ class Role extends Resource
      */
     public static function getModel(): string
     {
-        return app(PermissionRegistrar::class)->getRoleClass();
+        $roleClass = app(PermissionRegistrar::class)->getRoleClass();
+
+        return is_string($roleClass) ? $roleClass : get_class($roleClass);
     }
 
     /**


### PR DESCRIPTION
- Refactored `getModel()` to convert the object returned in Laravel Permissions v5 to class string