### PR TITLE
fix: nova 5 fillAttributeFromRequest type conformance

### DIFF
--- a/src/PermissionBooleanGroup.php
+++ b/src/PermissionBooleanGroup.php
@@ -35,13 +35,19 @@ class PermissionBooleanGroup extends BooleanGroup
 
     /**
      * @param NovaRequest $request
-     * @param string $requestAttribute
-     * @param HasPermissions $model
-     * @param string $attribute
+     * @param string      $requestAttribute
+     * @param object      $model
+     * @param string      $attribute
+     *
+     * @return void
      */
-    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
+    protected function fillAttributeFromRequest(NovaRequest $request, string $requestAttribute, object $model, string $attribute): void
     {
-        if (! $request->exists($requestAttribute)) {
+        if (!in_array(HasPermissions::class, class_uses_recursive($model))) {
+            throw new \InvalidArgumentException('The $model parameter of type ' . $model::class . ' must implement ' . HasPermissions::class);
+        }
+
+        if (!$request->exists($requestAttribute)) {
             return;
         }
 

--- a/src/RoleBooleanGroup.php
+++ b/src/RoleBooleanGroup.php
@@ -8,7 +8,7 @@ use Laravel\Nova\Fields\BooleanGroup;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Spatie\Permission\Models\Role as RoleModel;
 use Spatie\Permission\PermissionRegistrar;
-use Spatie\Permission\Traits\HasPermissions;
+use Spatie\Permission\Traits\HasRoles;
 
 class RoleBooleanGroup extends BooleanGroup
 {
@@ -35,13 +35,19 @@ class RoleBooleanGroup extends BooleanGroup
 
     /**
      * @param NovaRequest $request
-     * @param string $requestAttribute
-     * @param HasPermissions $model
-     * @param string $attribute
+     * @param string      $requestAttribute
+     * @param object      $model
+     * @param string      $attribute
+     *
+     * @return void
      */
-    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
+    protected function fillAttributeFromRequest(NovaRequest $request, string $requestAttribute, object $model, string $attribute): void
     {
-        if (! $request->exists($requestAttribute)) {
+        if (!in_array(HasRoles::class, class_uses_recursive($model))) {
+            throw new \InvalidArgumentException('The $model parameter of type ' . $model::class . ' must implement ' . HasRoles::class);
+        }
+
+        if (!$request->exists($requestAttribute)) {
             return;
         }
 

--- a/src/RoleSelect.php
+++ b/src/RoleSelect.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Collection;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Spatie\Permission\PermissionRegistrar;
-use Spatie\Permission\Traits\HasPermissions;
+use Spatie\Permission\Traits\HasRoles;
 
 class RoleSelect extends Select
 {
@@ -32,19 +32,25 @@ class RoleSelect extends Select
 
     /**
      * @param NovaRequest $request
-     * @param string $requestAttribute
-     * @param HasPermissions $model
-     * @param string $attribute
+     * @param string      $requestAttribute
+     * @param object      $model
+     * @param string      $attribute
+     *
+     * @return void
      */
-    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
+    protected function fillAttributeFromRequest(NovaRequest $request, string $requestAttribute, object $model, string $attribute): void
     {
-        if (! $request->exists($requestAttribute)) {
+        if (!in_array(HasRoles::class, class_uses_recursive($model))) {
+            throw new \InvalidArgumentException('The $model parameter of type ' . $model::class . ' must implement ' . HasRoles::class);
+        }
+
+        if (!$request->exists($requestAttribute)) {
             return;
         }
 
         $model->syncRoles([]);
 
-        if (! is_null($request[$requestAttribute])) {
+        if (!is_null($request[$requestAttribute])) {
             $roleClass = app(PermissionRegistrar::class)->getRoleClass();
             $role = $roleClass::where('name', $request[$requestAttribute])->first();
             $model->assignRole($role);


### PR DESCRIPTION
- Fixed type conformance for `Laravel\Nova\Fields\BooleanGroup::fillAttributeFromRequest` used in `PermissionBooleanGroup`, `RoleBooleanGroup`, and `RoleSelect`

Fixes #39