### PR TITLE
fix: address explicit nullable warning

### DIFF
--- a/src/PermissionBooleanGroup.php
+++ b/src/PermissionBooleanGroup.php
@@ -4,15 +4,27 @@ namespace Vyuldashev\NovaPermission;
 
 use Auth;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Laravel\Nova\Fields\BooleanGroup;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Spatie\Permission\Models\Permission as PermissionModel;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasPermissions;
+use Stringable;
 
 class PermissionBooleanGroup extends BooleanGroup
 {
-    public function __construct($name, $attribute = null, callable $resolveCallback = null, $labelAttribute = null)
+    /**
+     * Create a new field.
+     *
+     * @param Stringable|string                             $name
+     * @param string|callable|object|null                    $attribute
+     * @param (callable(mixed, mixed, ?string):(mixed))|null $resolveCallback
+     * @param string|null                                    $labelAttribute
+     *
+     * @return void
+     */
+    public function __construct($name, mixed $attribute = null, ?callable $resolveCallback = null, ?string $labelAttribute = null)
     {
         parent::__construct(
             $name,
@@ -44,7 +56,7 @@ class PermissionBooleanGroup extends BooleanGroup
     protected function fillAttributeFromRequest(NovaRequest $request, string $requestAttribute, object $model, string $attribute): void
     {
         if (!in_array(HasPermissions::class, class_uses_recursive($model))) {
-            throw new \InvalidArgumentException('The $model parameter of type ' . $model::class . ' must implement ' . HasPermissions::class);
+            throw new InvalidArgumentException('The $model parameter of type ' . $model::class . ' must implement ' . HasPermissions::class);
         }
 
         if (!$request->exists($requestAttribute)) {

--- a/src/RoleBooleanGroup.php
+++ b/src/RoleBooleanGroup.php
@@ -4,15 +4,27 @@ namespace Vyuldashev\NovaPermission;
 
 use Auth;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Laravel\Nova\Fields\BooleanGroup;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Spatie\Permission\Models\Role as RoleModel;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasRoles;
+use Stringable;
 
 class RoleBooleanGroup extends BooleanGroup
 {
-    public function __construct($name, $attribute = null, callable $resolveCallback = null, $labelAttribute = null)
+    /**
+     * Create a new field.
+     *
+     * @param Stringable|string                              $name
+     * @param string|callable|object|null                    $attribute
+     * @param null|(callable(mixed, mixed, ?string):(mixed)) $resolveCallback
+     * @param null|string                                    $labelAttribute
+     *
+     * @return void
+     */
+    public function __construct($name, mixed $attribute = null, ?callable $resolveCallback = null, ?string $labelAttribute = null)
     {
         parent::__construct(
             $name,
@@ -44,7 +56,7 @@ class RoleBooleanGroup extends BooleanGroup
     protected function fillAttributeFromRequest(NovaRequest $request, string $requestAttribute, object $model, string $attribute): void
     {
         if (!in_array(HasRoles::class, class_uses_recursive($model))) {
-            throw new \InvalidArgumentException('The $model parameter of type ' . $model::class . ' must implement ' . HasRoles::class);
+            throw new InvalidArgumentException('The $model parameter of type ' . $model::class . ' must implement ' . HasRoles::class);
         }
 
         if (!$request->exists($requestAttribute)) {

--- a/src/RoleSelect.php
+++ b/src/RoleSelect.php
@@ -8,10 +8,21 @@ use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasRoles;
+use Stringable;
 
 class RoleSelect extends Select
 {
-    public function __construct($name, $attribute = null, callable $resolveCallback = null, $labelAttribute = null)
+    /**
+     * Create a new field.
+     *
+     * @param Stringable|string                              $name
+     * @param string|callable|object|null                    $attribute
+     * @param (callable(mixed, mixed, ?string):(mixed))|null $resolveCallback
+     * @param string|null                                    $labelAttribute
+     *
+     * @return void
+     */
+    public function __construct($name, mixed $attribute = null, ?callable $resolveCallback = null, ?string $labelAttribute = null)
     {
         parent::__construct(
             $name,


### PR DESCRIPTION
- Marked nullable parameters explicitly as nullable to address deprecation warning in PHP 8.4

Fixes #42